### PR TITLE
Feature: initial implementation

### DIFF
--- a/Offline.xcodeproj/project.pbxproj
+++ b/Offline.xcodeproj/project.pbxproj
@@ -11,6 +11,16 @@
 		D56C56831D8779D10078585E /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C56811D8779CE0078585E /* Extensions.swift */; };
 		D56C56911D8779F20078585E /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C568B1D8779E60078585E /* Tests.swift */; };
 		D56C56921D8779F30078585E /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C568B1D8779E60078585E /* Tests.swift */; };
+		D56C56951D87FE180078585E /* ConcurrentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C56941D87FE180078585E /* ConcurrentOperation.swift */; };
+		D56C56961D87FE180078585E /* ConcurrentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C56941D87FE180078585E /* ConcurrentOperation.swift */; };
+		D56C56981D87FE5C0078585E /* DataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C56971D87FE5C0078585E /* DataOperation.swift */; };
+		D56C56991D87FE5C0078585E /* DataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C56971D87FE5C0078585E /* DataOperation.swift */; };
+		D56C569B1D87FE920078585E /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C569A1D87FE920078585E /* Networking.swift */; };
+		D56C569C1D87FE920078585E /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C569A1D87FE920078585E /* Networking.swift */; };
+		D56C569E1D87FEAF0078585E /* RequestRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C569D1D87FEAF0078585E /* RequestRestorer.swift */; };
+		D56C569F1D87FEAF0078585E /* RequestRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C569D1D87FEAF0078585E /* RequestRestorer.swift */; };
+		D56C56A11D87FED30078585E /* RequestStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C56A01D87FED30078585E /* RequestStorage.swift */; };
+		D56C56A21D87FED30078585E /* RequestStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56C56A01D87FED30078585E /* RequestStorage.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Offline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Offline.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* Offline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Offline.framework */; };
 /* End PBXBuildFile section */
@@ -39,6 +49,11 @@
 		D56C56871D8779E60078585E /* Info-Tests-iOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Tests-iOS.plist"; sourceTree = "<group>"; };
 		D56C56881D8779E60078585E /* Info-Tests-Mac.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Tests-Mac.plist"; sourceTree = "<group>"; };
 		D56C568B1D8779E60078585E /* Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		D56C56941D87FE180078585E /* ConcurrentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentOperation.swift; sourceTree = "<group>"; };
+		D56C56971D87FE5C0078585E /* DataOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataOperation.swift; sourceTree = "<group>"; };
+		D56C569A1D87FE920078585E /* Networking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		D56C569D1D87FEAF0078585E /* RequestRestorer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRestorer.swift; sourceTree = "<group>"; };
+		D56C56A01D87FED30078585E /* RequestStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestStorage.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Offline.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Offline.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2E8A91C3A780C00C0327D /* Offline-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Offline-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C629401C3A7FAA007F7B7C /* Offline.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Offline.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -106,6 +121,15 @@
 			path = Offline;
 			sourceTree = "<group>";
 		};
+		D56C56931D87FE0C0078585E /* Operation */ = {
+			isa = PBXGroup;
+			children = (
+				D56C56941D87FE180078585E /* ConcurrentOperation.swift */,
+				D56C56971D87FE5C0078585E /* DataOperation.swift */,
+			);
+			path = Operation;
+			sourceTree = "<group>";
+		};
 		D5B2E8951C3A780C00C0327D = {
 			isa = PBXGroup;
 			children = (
@@ -130,7 +154,11 @@
 		D5C629691C3A809D007F7B7C /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				D56C56931D87FE0C0078585E /* Operation */,
 				D56C56811D8779CE0078585E /* Extensions.swift */,
+				D56C569A1D87FE920078585E /* Networking.swift */,
+				D56C569D1D87FEAF0078585E /* RequestRestorer.swift */,
+				D56C56A01D87FED30078585E /* RequestStorage.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -307,7 +335,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D56C56951D87FE180078585E /* ConcurrentOperation.swift in Sources */,
+				D56C56A11D87FED30078585E /* RequestStorage.swift in Sources */,
+				D56C56981D87FE5C0078585E /* DataOperation.swift in Sources */,
+				D56C569E1D87FEAF0078585E /* RequestRestorer.swift in Sources */,
 				D56C56821D8779CE0078585E /* Extensions.swift in Sources */,
+				D56C569B1D87FE920078585E /* Networking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -323,7 +356,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D56C56961D87FE180078585E /* ConcurrentOperation.swift in Sources */,
+				D56C56A21D87FED30078585E /* RequestStorage.swift in Sources */,
+				D56C56991D87FE5C0078585E /* DataOperation.swift in Sources */,
+				D56C569F1D87FEAF0078585E /* RequestRestorer.swift in Sources */,
 				D56C56831D8779D10078585E /* Extensions.swift in Sources */,
+				D56C569C1D87FE920078585E /* Networking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -1,1 +1,8 @@
-import UIKit
+import Foundation
+
+extension NSError {
+
+  var isOffline: Bool {
+    return Int32(code) == CFNetworkErrors.CFURLErrorNotConnectedToInternet.rawValue
+  }
+}

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -1,9 +1,45 @@
-//
-//  Networking.swift
-//  Offline
-//
-//  Created by Vadym Markov on 13/09/16.
-//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
-//
-
 import Foundation
+
+public final class Networking {
+
+  public enum Kind {
+    case Sync, Async, Limited(Int)
+  }
+
+  public let kind: Kind
+  private let session: NSURLSession
+  private let queue: NSOperationQueue
+
+  // MARK: - Initialization
+
+  public init(kind: Kind, session: NSURLSession = NSURLSession.sharedSession()) {
+    self.kind = kind
+    self.session = session
+    queue = NSOperationQueue()
+
+    switch kind {
+    case .Sync:
+      queue.maxConcurrentOperationCount = 1
+    case .Async:
+      queue.maxConcurrentOperationCount = -1
+    case .Limited(let count):
+      queue.maxConcurrentOperationCount = count
+    }
+  }
+
+  // MARK: - Data request
+
+  public func send(request: NSURLRequest, saveOffline: Bool = false, completion: DataTaskCompletion) {
+    let operation = DataOperation(session: session, request: request) {
+      data, response, error in
+
+      if saveOffline && error?.isOffline == true {
+        RequestStorage.shared.save(request)
+      }
+
+      completion(data, response, error)
+    }
+
+    queue.addOperation(operation)
+  }
+}

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -1,0 +1,9 @@
+//
+//  Networking.swift
+//  Offline
+//
+//  Created by Vadym Markov on 13/09/16.
+//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Sources/Operation/ConcurrentOperation.swift
+++ b/Sources/Operation/ConcurrentOperation.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+class ConcurrentOperation: NSOperation {
+
+  enum State: String {
+    case Ready = "isReady"
+    case Executing = "isExecuting"
+    case Finished = "isFinished"
+  }
+
+  var state = State.Ready {
+    willSet {
+      willChangeValueForKey(newValue.rawValue)
+      willChangeValueForKey(state.rawValue)
+    }
+    didSet {
+      didChangeValueForKey(oldValue.rawValue)
+      didChangeValueForKey(state.rawValue)
+    }
+  }
+
+  override var asynchronous: Bool {
+    return true
+  }
+
+  override var ready: Bool {
+    return super.ready && state == .Ready
+  }
+
+  override var executing: Bool {
+    return state == .Executing
+  }
+
+  override var finished: Bool {
+    return state == .Finished
+  }
+
+  override func start() {
+    guard !cancelled else {
+      state = .Finished
+      return
+    }
+
+    execute()
+  }
+
+  func execute() {
+    state = .Executing
+  }
+}

--- a/Sources/Operation/DataOperation.swift
+++ b/Sources/Operation/DataOperation.swift
@@ -1,9 +1,31 @@
-//
-//  NetworkDataOperation.swift
-//  Offline
-//
-//  Created by Vadym Markov on 13/09/16.
-//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
-//
-
 import Foundation
+
+public typealias DataTaskCompletion = (NSData?, NSURLResponse?, NSError?) -> Void
+
+class DataOperation: ConcurrentOperation {
+
+  private let session: NSURLSession
+  private let request: NSURLRequest
+  private let completion: DataTaskCompletion
+  private var task: NSURLSessionDataTask?
+
+  init(session: NSURLSession, request: NSURLRequest, completion: DataTaskCompletion) {
+    self.session = session
+    self.request = request
+    self.completion = completion
+  }
+
+  override func execute() {
+    task = session.dataTaskWithRequest(request) { [weak self] (data, response, error) in
+      self?.completion(data, response, error)
+      self?.state = .Finished
+    }
+
+    task?.resume()
+  }
+
+  override func cancel() {
+    super.cancel()
+    task?.cancel()
+  }
+}

--- a/Sources/Operation/DataOperation.swift
+++ b/Sources/Operation/DataOperation.swift
@@ -1,0 +1,9 @@
+//
+//  NetworkDataOperation.swift
+//  Offline
+//
+//  Created by Vadym Markov on 13/09/16.
+//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Sources/RequestRestorer.swift
+++ b/Sources/RequestRestorer.swift
@@ -1,0 +1,9 @@
+//
+//  RequestRestorer.swift
+//  Offline
+//
+//  Created by Vadym Markov on 13/09/16.
+//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Sources/RequestRestorer.swift
+++ b/Sources/RequestRestorer.swift
@@ -1,9 +1,54 @@
-//
-//  RequestRestorer.swift
-//  Offline
-//
-//  Created by Vadym Markov on 13/09/16.
-//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
-//
-
 import Foundation
+
+public final class RequestRestorer {
+
+  public typealias Before = (NSMutableURLRequest, (NSURLRequest -> Void)) -> Void
+  public typealias Completion = (NSURLRequest, NSURLResponse?, NSError?) -> Void
+
+  public var before: Before = { request, completion in completion(request) }
+  public var running = false
+
+  let networking: Networking
+
+  // MARK: - Initialization
+
+  init(networking: Networking) {
+    self.networking = networking
+  }
+
+  // MARK: - Replay
+
+  public func replay(completion: Completion? = nil) {
+    let requests = RequestStorage.shared.requests
+
+    guard !running && requests.count > 0 else {
+      return
+    }
+
+    running = true
+
+    var count = requests.count
+
+    for request in requests.values {
+      guard let mutableRequest = request.mutableCopy() as? NSMutableURLRequest else {
+        continue
+      }
+
+      before(mutableRequest) { [weak self] request in
+        self?.networking.send(request) { [weak self] data, response, error in
+          if error?.isOffline != true {
+            RequestStorage.shared.remove(request)
+          }
+
+          completion?(request, response, error)
+
+          count -= 1
+
+          if count == 0 {
+            self?.running = false
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/RequestStorage.swift
+++ b/Sources/RequestStorage.swift
@@ -1,0 +1,9 @@
+//
+//  RequestStorage.swift
+//  Offline
+//
+//  Created by Vadym Markov on 13/09/16.
+//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Sources/RequestStorage.swift
+++ b/Sources/RequestStorage.swift
@@ -1,9 +1,63 @@
-//
-//  RequestStorage.swift
-//  Offline
-//
-//  Created by Vadym Markov on 13/09/16.
-//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
-//
-
 import Foundation
+
+public final class RequestStorage {
+  let key = "Offline.RequestStorage"
+
+  public static let shared: RequestStorage = RequestStorage()
+
+  public private(set) var requests = [String: NSURLRequest]()
+
+  private var userDefaults: NSUserDefaults {
+    return NSUserDefaults.standardUserDefaults()
+  }
+
+  // MARK: - Initialization
+
+  init() {
+    requests = load()
+  }
+
+  // MARK: - Save
+
+  public func save(request: NSURLRequest) {
+    guard let key = request.URL?.absoluteString else {
+      return
+    }
+
+    requests[key] = request
+    saveAll()
+  }
+
+  public func saveAll() {
+    let data = NSKeyedArchiver.archivedDataWithRootObject(requests)
+    userDefaults.setObject(data, forKey: key)
+    userDefaults.synchronize()
+  }
+
+  // MARK: - Remove
+
+  public func remove(request: NSURLRequest) {
+    guard let key = request.URL?.absoluteString else {
+      return
+    }
+
+    requests.removeValueForKey(key)
+    saveAll()
+  }
+
+  public func clear() {
+    requests.removeAll()
+    userDefaults.removeObjectForKey(key)
+    userDefaults.synchronize()
+  }
+
+  // MARK: - Load
+
+  func load() -> [String: NSURLRequest] {
+    guard let data = userDefaults.objectForKey(key) as? NSData,
+      dictionary = NSKeyedUnarchiver.unarchiveObjectWithData(data) as? [String: NSURLRequest]
+      else { return [:] }
+
+    return dictionary
+  }
+}


### PR DESCRIPTION
@zenangst @RamonGilabert @onmyway133 @attila-at-hyper 

This library is framework agnostic and could be used in the combination with every networking library (I believe).

`RequestStorage` uses `NSUserDefaults` to load/save/remove requests that need to be replayed when user appears online.

`Networking` is a wrapper around `NSURLSession` that helps to perform requests sync/async. It will also cache request if was executed while offline.

`RequestRestorer` should be called when connection is reachable, then it goes through every cached request and tries to replay them.
